### PR TITLE
商品情報編集_1回目

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
+  before_action :set_item, only: [:edit, :show, :update]
   before_action :move_to_index, except: [:index, :show, :new, :create]
 
   def index
@@ -20,15 +21,12 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path
     else
@@ -42,8 +40,11 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:item_name, :item_description, :item_category_id, :item_state_id, :shipping_cost_id, :prefecture_id, :shipping_day_id, :price, :image).merge(user_id: current_user.id)
   end
 
-  def move_to_index
+  def set_item
     @item = Item.find(params[:id])
+  end
+
+  def move_to_index
     unless current_user.id == @item.user_id 
       redirect_to action: :index
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: :new
+  before_action :authenticate_user!, except: [:show, :index]
+  before_action :move_to_index, except: [:index, :show, :new, :create]
 
   def index
     @items = Item.all.order("created_at DESC")
@@ -22,10 +23,30 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path
+    else
+      render :edit
+    end
+  end
+
   private
 
   def item_params
     params.require(:item).permit(:item_name, :item_description, :item_category_id, :item_state_id, :shipping_cost_id, :prefecture_id, :shipping_day_id, :price, :image).merge(user_id: current_user.id)
+  end
+
+  def move_to_index
+    @item = Item.find(params[:id])
+    unless current_user.id == @item.user_id 
+      redirect_to action: :index
+    end
   end
 
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,11 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-
-
-    <%= form_with local: @item, url: items_path, true do |f| %>
-    
-
+    <%= form_with model: @item, url: item_path, local: true do |f| %>
     <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
@@ -28,6 +24,7 @@ app/assets/stylesheets/items/new.css %>
       </div>
     </div>
     <%# /商品画像 %>
+    
     <%# 商品名と商品説明 %>
     <div class="new-items">
       <div class="weight-bold-text">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,9 +130,7 @@
       <ul class='item-lists'>
         <% @items.each do |item| %>
           <li class='list'>
-            <%# 詳細表示でパスの再設定、showアクションがポイント %>
             <%= link_to item_path(item.id), method: :get do %>
-            <%# 詳細表示でパスの再設定、showアクションがポイント %>
               <div class='item-img-content'>
                 <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
 
     <% if user_signed_in? %>
       <% if current_user.id == @item.user_id %>
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
       <% else %>
@@ -105,9 +105,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= @item.item_category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,6 @@ Rails.application.routes.draw do
   get 'items/index'
   root to: "items#index"
   
-  resources :items, only: [:new, :create, :index, :show]
+  resources :items, only: [:new, :create, :index, :show, :edit, :update]
   
 end


### PR DESCRIPTION
# What
画像を含む商品の情報を編集する機能を実装した。

# Why
投稿したユーザー以外が編集などできないような一定量の制限が必要な為。
Twitterなどと同様に、一覧は見れても他の人のtweetそのものの操作ができないのと一緒の考え方となる。

# GYAZOの添付
- ログイン状態の出品者は、商品情報編集ページに遷移できる動画
- 必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
- 入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
- 何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
- ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
- ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
- 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）

https://i.gyazo.com/43f2fe4546d6af0831d8fe75c19ccea4.gif
https://i.gyazo.com/7e2583150f87d48ba5948112ed2253dd.gif
https://i.gyazo.com/a3ce3015220e9dd04d6d0fbe57644198.gif
https://i.gyazo.com/23935293ea7f89f29f509aa50932939b.gif
https://i.gyazo.com/358f588a6ec5cd8a6856b98ad205361a.gif
https://i.gyazo.com/1be40718c03b08ab47f4eeac6f66eaf5.gif
https://i.gyazo.com/bc0b6cd4076d476a2d73666d1d394e1a.gif