### PR TITLE
商品削除機能_1回目

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
-  before_action :set_item, only: [:edit, :show, :update]
+  before_action :set_item, only: [:edit, :show, :update, :destroy]
   before_action :move_to_index, except: [:index, :show, :new, :create]
 
   def index
@@ -31,6 +31,12 @@ class ItemsController < ApplicationController
       redirect_to item_path
     else
       render :edit
+    end
+  end
+
+  def destroy
+    if @item.destroy
+      redirect_to root_path
     end
   end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
       <% else %>
       <%# 商品が売れていない場合は購入画面に遷移、購入の実装後に再度設定する %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,6 @@ Rails.application.routes.draw do
   get 'items/index'
   root to: "items#index"
   
-  resources :items, only: [:new, :create, :index, :show, :edit, :update]
+  resources :items
   
 end


### PR DESCRIPTION
# What
商品の情報を削除する機能を実装する為。

# Why
投稿したユーザーのみ実装できるように設定、第三者が削除できないようにすることもポイントとなってくる。

# gyazoの添付
- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://i.gyazo.com/4332602849dbfc3a86c9725cec642244.gif